### PR TITLE
Added ISQLStatement protocol

### DIFF
--- a/src/jdbc/types.clj
+++ b/src/jdbc/types.clj
@@ -32,6 +32,9 @@
 
   (from-sql-type [_ conn metadata index] "Convert sql type to user type."))
 
+(defprotocol ISQLStatement
+  (normalize [this conn options]))
+
 (extend-protocol ISQLType
   Object
   (as-sql-type [this conn] this)


### PR DESCRIPTION
Added ISQLStatement protocol to allow for pluggable statement transformations.  For example, translate a hash map return by HoneySQL.
