### PR TITLE
fixed max-rows bug and added missing fetch-size option

### DIFF
--- a/src/jdbc/core.clj
+++ b/src/jdbc/core.clj
@@ -305,8 +305,11 @@ can be complete objects."
      ;; Overwrite default jdbc driver fetch-size when user
      ;; wants lazy result set.
      (when lazy (.setFetchSize stmt fetch-size))
-     (when max-rows (.setMaxRows max-rows))
 
+     ;; Set fetch-size and max-rows if provided by user
+     (when fetch-size (.setFetchSize stmt fetch-size))
+     (when max-rows (.setMaxRows stmt max-rows))
+     
      (when (seq params)
        (->> params
             (map-indexed #(types/set-stmt-parameter! %2 conn stmt (inc %1)))


### PR DESCRIPTION
Fixed `(with-connection [conn dbspec]
             (query conn ["SELECT * FROM table"] {:max-rows 10}))`
throwing `IllegalArgumentException No matching field found: setMaxRows for class java.lang.Long` . 

Added fetch-size option, which was otherwise ignored.

```
Ran 12 tests containing 86 assertions.
0 failures, 0 errors.
```
