### PR TITLE
Fix c3p0 example docment error.

### DIFF
--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -487,6 +487,7 @@ an little example on how it can be done:
 (def ds (doto (ComboPooledDataSource.)
           (.setJdbcUrl (str "jdbc:"
                             (:subprotocol dbspec)
+                            ":"
                             (:subname dbspec)))
           (.setUser (:user dbspec nil))
           (.setPassword (:password dbspec nil))


### PR DESCRIPTION
jdbcUrl format `jdbc:subprotocol:subname`