### PR TITLE
Documentation for fetch-lazy and prepared-statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@ A JDBC library for Clojure.
 ## Documentation ##
 
 - **Documentation:** http://funcool.github.io/clojure.jdbc/latest/
+
+- **API Docs** https://funcool.github.io/clojure.jdbc/latest/api/index.html

--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -10,14 +10,11 @@ Andrey Antukh, <niwi@niwi.nz>
 :idprefix:
 :!numbered:
 
+== link:api/index.html[API reference documentation]
 
 == Introduction
 
 _clojure.jdbc_ is a library for low level, jdbc-based database access.
-
-
-link:api/index.html[Api reference documentation.]
-
 
 === Install
 

--- a/src/jdbc/core.clj
+++ b/src/jdbc/core.clj
@@ -99,7 +99,16 @@
 
 (defn prepared-statement
   "Given a string or parametrized sql in sqlvec format
-  return an instance of prepared statement."
+  return an instance of prepared statement.
+  `options` is an optional map with these keys (all optional):
+  - :result-type - A keyword indicating the java.sql.ResultSet type. Any of :forward-only, :scroll-insensitive, :scroll-sensitive.
+  - :result-concurrency - A keyword indicating the concurrency mode of the java.sql.ResultSet object. Either :read-only or :updatable.
+  - :fetch-size - An integer indicating the number of rows to fetch at once.
+  - :max-rows - An integer indicating the maximumal number of rows that may be fetched.
+  - :holdability - A keyword indicating whether cursors should be held or closed on commit. Either :hold or :close.
+  - :returning - Either true or :all, to indicate that the generated keys for new rows should be returned, or a sequence of keywords indicating the names of rows to return.
+
+  More information about these options can be found in the [javadoc](https://docs.oracle.com/javase/8/docs/api/java/sql/ResultSet.html)."
   ([conn sqlvec] (prepared-statement conn sqlvec {}))
   ([conn sqlvec options]
    (let [conn (proto/connection conn)]
@@ -146,11 +155,20 @@
 
   This function returns a cursor instead of result.
   You should explicitly close the cursor at the end of
-  iteration for release resources."
+  iteration for release resources.
+
+  `options` is an optional map with these keys (all optional):
+  - :result-type - A keyword indicating the java.sql.ResultSet type. Any of :forward-only, :scroll-insensitive, :scroll-sensitive.
+  - :result-concurrency - A keyword indicating the concurrency mode of the java.sql.ResultSet object. Either :read-only or :updatable.
+  - :fetch-size - An integer indicating the number of rows to fetch at once.
+  - :max-rows - An integer indicating the maximumal number of rows that may be fetched.
+  - :holdability - A keyword indicating whether cursors should be held or closed on commit. Either :hold or :close.
+
+  More information about these options can be found in the [javadoc](https://docs.oracle.com/javase/8/docs/api/java/sql/ResultSet.html)."
   ([conn q] (fetch-lazy conn q {}))
-  ([conn q opts]
+  ([conn q options]
    (let [^Connection conn (proto/connection conn)
-         ^PreparedStatement stmt (proto/prepared-statement q conn opts)]
+         ^PreparedStatement stmt (proto/prepared-statement q conn options)]
      (types/->cursor stmt))))
 
 (def ^{:doc "Deprecated alias for backward compatibility."

--- a/src/jdbc/impl.clj
+++ b/src/jdbc/impl.clj
@@ -191,10 +191,10 @@
 (defn- prepared-statement*
   "Given connection and query, return a prepared statement."
   ([^Connection conn sqlvec] (prepared-statement* conn sqlvec {}))
-  ([^Connection conn sqlvec {:keys [result-type result-concurency fetch-size
+  ([^Connection conn sqlvec {:keys [result-type result-concurrency fetch-size
                                     max-rows holdability returning]
                              :or {result-type :forward-only
-                                  result-concurency :read-only}
+                                  result-concurrency :read-only}
                              :as options}]
    (let [sqlvec (if (string? sqlvec) [sqlvec] sqlvec)
          ^String sql (first sqlvec)
@@ -211,12 +211,12 @@
                holdability
                (.prepareStatement conn sql
                                   (result-type constants/resultset-options)
-                                  (result-concurency constants/resultset-options)
+                                  (result-concurrency constants/resultset-options)
                                   (holdability constants/resultset-options))
                :else
                (.prepareStatement conn sql
                                   (result-type constants/resultset-options)
-                                  (result-concurency constants/resultset-options)))]
+                                  (result-concurrency constants/resultset-options)))]
 
      ;; Set fetch-size and max-rows if provided by user
      (when fetch-size (.setFetchSize stmt fetch-size))


### PR DESCRIPTION
Fixes #44.
Note that this is a breaking change, because I also fixed the typo in the `:result-concurrency` option's name.